### PR TITLE
纠正 websocket.md 的一处表达不当

### DIFF
--- a/docs/zh-cn/websocket.md
+++ b/docs/zh-cn/websocket.md
@@ -10,7 +10,7 @@
 
 Gateway 是 websocket 的网关，客户端通过连接 Gateway 可以获取到相应的推送消息等。
 
-Gateway 的获取需要走 http 接口获取，参见[Gateway](https://developer.kaiheila.cn/doc/http/gateway)
+Gateway 的地址需要走 http 接口获取，参见[Gateway](https://developer.kaiheila.cn/doc/http/gateway)
 
 ## 消息压缩
 


### PR DESCRIPTION
更改了 websocket.md 有关 Gateway 的部分。
原句 "Gateway 的获取需要走 http 接口获取" 存在语意重复。
此句有两种改法。
"Gateway 的地址需要走 http 接口获取"
或者
"Gateway 的获取需要走 http 接口"

此PR选择前种改法。